### PR TITLE
admin商品一覧ページのレイアウト変更

### DIFF
--- a/app/views/admin/items/index.html.erb
+++ b/app/views/admin/items/index.html.erb
@@ -8,9 +8,10 @@
             <i class="fas fa-plus"></i>
             <% end %>
         </div>
+    </div>    
         <div class="row">
-            <div class="col-sm-10 px-sm-o mx-auto mb-5">
-                <table class="table text-center admin-items mb-5">
+            <div class="col-sm-10 offset-1">
+                <table class="table  mb-5">
                     <thread>
                         <tr>
                             <th>商品ID</th>
@@ -41,5 +42,4 @@
                 <%= paginate @items %>
             </div>
         </div>
-    </div>
 </div>


### PR DESCRIPTION
商品一覧の表示横幅がページの半分しか表示されなかったのを、
画面幅いっぱいまでに変更

原因
画面タイトル部分のrowと商品一覧部分のrowが区切られずごちゃごちゃになっていた。

区切るとうまく表示された


