### PR TITLE
[管理者側　注文履歴表示]

### DIFF
--- a/app/controllers/admin/orders_controller.rb
+++ b/app/controllers/admin/orders_controller.rb
@@ -1,7 +1,7 @@
 class Admin::OrdersController < ApplicationController
    before_action :authenticate_admin!
   def index
-    
+    @orders = Order.page(params[:page]).per(10)
   end
   
   def show
@@ -19,4 +19,5 @@ class Admin::OrdersController < ApplicationController
   def current_index
     
   end
+  
 end

--- a/app/controllers/public/orders_controller.rb
+++ b/app/controllers/public/orders_controller.rb
@@ -58,26 +58,27 @@ class Public::OrdersController < ApplicationController
   def create
     @order = current_customer.orders.new(order_params)
     @order.save
-    flash[:notice] = "ご注文が確定しました。"
-    redirect_to thanx_orders_path
+    
     # 情報入力に新規配送先があれば保存
     if params[:order][:ship] =="1"
       current_customer.address.create(address_params)
     end
-
-    # カート商品の情報を注文履歴に移動させる
-    @cart_items = current_cart
+    
+       # カート商品の情報を注文履歴に移動させる
+    @cart_items = current_customer.cart_items
     @cart_items.each do |cart_item|
-      OrderDetail.create(
-        item: cart_item.item,
-        order: @order,
-        count: cart_item.count,
-        price: @order.total_payment
-        )
+      @order_detail = OrderDetail.new
+      @order_detail.item_id = cart_item.item_id
+      @order_detail.order_id = @order.id
+      @order_detail.count = cart_item.count
+      @order_detail.making_status = 0
+      @order_detail.price = cart_item.item.price
+      @order.save
       end
-
     # 最後にカートを全て削除する
     @cart_items.destroy_all
+    
+    redirect_to thanx_orders_path
   end
 
   def thanx

--- a/app/views/admin/orders/index.html.erb
+++ b/app/views/admin/orders/index.html.erb
@@ -1,0 +1,27 @@
+<div class="container">
+  <h2 class="my-5">注文履歴一覧</h2>
+  <table class="table">
+    <thead>
+      <tr>
+        <th>購入日時</th>
+        <th>購入者</th>
+        <th>注文個数</th>
+        <th>注文ステータス</th>
+      </tr>      
+      <tbody>
+        <% @orders.each do |order| %>
+        <tr>
+          <td>
+            <%= link_to admin_order_path(order) do%>
+              <%= order.created_at%>
+            <% end %>
+          </td>
+          <td><%= full_name(order.customer)%></td>
+          <td><%= order.order_details.count%></td>
+          <td><%= order.status%></td>
+        </tr>
+        <% end %>
+      </tbody>
+    </thead>    
+  </table>
+</div>

--- a/app/views/public/orders/confirm.html.erb
+++ b/app/views/public/orders/confirm.html.erb
@@ -73,12 +73,12 @@
   
   <div class="row">
     <h3 class="mx-auto">
-      <%= form_with model: @order, url: orders_path, local: true do |f|%>
-        <%= f.hidden_field :payment_method, :value => @order.payment_method %>
-        <%= f.hidden_field :postal_code, :value => @order.postal_code%>
-        <%= f.hidden_field :address, :value => @order.address %>
-        <%= f.hidden_field :name, :value => @order.name %>
-        <%= f.hidden_field :total_payment, :value => @sub_total%>
+      <%= form_with model: @order, url: orders_path, method: :post, local: true do |f|%>
+        <%= f.hidden_field :payment_method %>
+        <%= f.hidden_field :postal_code%>
+        <%= f.hidden_field :address%>
+        <%= f.hidden_field :name%>
+        <%= f.hidden_field :total_payment%>
         <%= f.submit '注文を確定する', class:'btn btn-success'%>
       <% end %>
     </h3>


### PR DESCRIPTION
管理者側での注文履歴表示確認済み

[修正＆追加]
会員側での注文確認ページ、データの保存が出来ていなかった。
・form_withにmethod
・コントローラーに空のOrderDetaiを追加してデーターを保存できるようにした。

その後は、カートは空になる。マイページから注文履歴が入るようにもなっている。