### PR TITLE
注文履歴詳細バグ修正

### DIFF
--- a/app/controllers/public/orders_controller.rb
+++ b/app/controllers/public/orders_controller.rb
@@ -71,7 +71,7 @@ class Public::OrdersController < ApplicationController
       @order_detail.item_id = cart_item.item_id
       @order_detail.order_id = @order.id
       @order_detail.count = cart_item.count
-      @order_detail.price = cart_item.item.price
+      @order_detail.price = cart_item.item.price * cart_item.count 
       @order_detail.save
       end
     # 最後にカートを全て削除する

--- a/app/controllers/public/orders_controller.rb
+++ b/app/controllers/public/orders_controller.rb
@@ -8,7 +8,7 @@ class Public::OrdersController < ApplicationController
   end
 
   def show
-    @order = Order.find_by(params[:id])
+    @order = Order.find(params[:id])
     @order_details = @order.order_details
   end
 
@@ -58,12 +58,12 @@ class Public::OrdersController < ApplicationController
   def create
     @order = current_customer.orders.new(order_params)
     @order.save
-    
+
     # 情報入力に新規配送先があれば保存
     if params[:order][:ship] =="1"
       current_customer.address.create(address_params)
     end
-    
+
        # カート商品の情報を注文履歴に移動させる
     @cart_items = current_customer.cart_items
     @cart_items.each do |cart_item|
@@ -76,7 +76,7 @@ class Public::OrdersController < ApplicationController
       end
     # 最後にカートを全て削除する
     @cart_items.destroy_all
-    
+
     redirect_to thanx_orders_path
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -2,26 +2,22 @@ module ApplicationHelper
   def full_name(customer)
     customer.last_name + customer.first_name
   end
-  
+
   def kana_full_name(customer)
     customer.kana_last_name + customer.kana_first_name
   end
-  
+
   def full_address(key)
     "#{key.postal_code}#{key.address}"
   end
-  
+
   def current_cart
     @cart_items = current_customer.cart_items
-  end
-  
-  def tax_price(price)
-    (price * 1.1).floor
   end
 
   # 小計の計算
   def sub_price(sub)
-    (tax_price(sub.item.price) * sub.count)
+    sub.item.tax_in_price * sub.count
   end
 
   # 合計金額の計算
@@ -32,8 +28,8 @@ module ApplicationHelper
     end
     return price
   end
-  
-  
+
+
   def billing(order)
     total_price(current_cart) + order.shipping_cost
   end
@@ -47,5 +43,5 @@ module ApplicationHelper
 	    base + "/" + "#{title}"
 	  end
 	end
-	
+
 end

--- a/app/helpers/public/cart_items_helper.rb
+++ b/app/helpers/public/cart_items_helper.rb
@@ -1,10 +1,6 @@
 module Public::CartItemsHelper
-  def tax_in_price(cart_item)
-    (cart_item.item.price * 1.1).to_i
-  end
-
   def subtotal(cart_item)
-    tax_in_price(cart_item) * cart_item.count
+    cart_item.item.tax_in_price * cart_item.count
   end
 
   def total_price(cart_items)

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,3 +1,7 @@
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
+
+  def tax_in_price
+    (price * 1.1).floor
+  end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -4,13 +4,11 @@ class Item < ApplicationRecord
   belongs_to :genre
   has_many :orders, through: :order_details
 
-
   attachment :image
-  
+
   validates :name, presence: true
   validates :image, presence: true
   validates :introduction, presence: true
   validates :price, presence: true
   validates :genre_id, presence: true
-   
 end

--- a/app/views/admin/items/show.html.erb
+++ b/app/views/admin/items/show.html.erb
@@ -25,7 +25,7 @@
                   <%= "税込価格" %><br>
                   <%= "(税抜価格)" %>
               </th>
-              <td><%= (@item.price*1.1).to_i %>   (<%= @item.price %>) 円</td>
+              <td><%= @item.tax_in_price %> (<%= @item.price %>) 円</td>
             </tr>
             <tr>
               <th><%= "販売ステータス" %></th>
@@ -35,7 +35,7 @@
                      <% else %>
                         <p class="text-secondary ">販売停止中</p>
                      <% end %>
-                </td>     
+                </td>
             </tr>
      　　　　 </table>
      　　　　 <%= link_to '編集する', edit_admin_item_path(@item.id), class: 'btn btn-success' %>

--- a/app/views/admin/orders/show.html.erb
+++ b/app/views/admin/orders/show.html.erb
@@ -37,7 +37,7 @@
           <% @order.order_details.each do |order_detail|%>
             <tr>
               <td><p><%= order_detail.item.name%></p></td>
-              <td><p><%= tax_price(order_detail.item.price)%></p></td>
+              <td><p><%= order_detail.item.tax_in_price %></p></td>
               <td><p><%= order_detail.count%></p></td>
               <td><p><%= sub_price(order_detail)%></p></td>
               <td>

--- a/app/views/public/cart_items/index.html.erb
+++ b/app/views/public/cart_items/index.html.erb
@@ -16,7 +16,7 @@
           <%= attachment_image_tag i.item, :image, size: "55x43", fallback: "no_image.jpg" %>
           <%= i.item.name %>
         </th>
-        <th><%= tax_in_price(i).to_s(:delimited, delimiter: ',') %></th>
+        <th><%= i.item.tax_in_price.to_s(:delimited, delimiter: ',') %></th>
         <th>
           <%= form_with model:i, url: cart_item_path(i), method: :patch , remote: true do |f| %>
           <%= f.number_field :count, size: 10, min: 1 %>

--- a/app/views/public/orders/confirm.html.erb
+++ b/app/views/public/orders/confirm.html.erb
@@ -19,7 +19,7 @@
                 <%= cart.item.name %>
               </td>
               <td class="text-right">
-                ¥<%= tax_price(cart.item.price).to_s(:delimited) %>
+                ¥<%= cart.item.tax_in_price.to_s(:delimited) %>
               </td>
               <td class="text-right">
                   <%= cart.count %>
@@ -32,7 +32,7 @@
         </tbody>
       </table>
     </div>
-    
+
     <div class="col-xs-3 offset-md-1">
       <table class="table">
           <tr>
@@ -70,7 +70,7 @@
       </table>
     </div>
   </div>
-  
+
   <div class="row">
     <h3 class="mx-auto">
       <%= form_with model: @order, url: orders_path, method: :post, local: true do |f|%>

--- a/app/views/public/orders/show.html.erb
+++ b/app/views/public/orders/show.html.erb
@@ -16,7 +16,7 @@
         </td>
       </tr>
       <tr>
-      　<th>支払方法</th>
+        <th>支払方法</th>
         <td><%= @order.payment_method %></td>
       </tr>
       <tr>
@@ -43,20 +43,20 @@
 	<strong>注文内容</strong>
   <table class="table table-striped table-bordered table-condensed">
   	<thead>
-    <tr>
-    	<th>商品</th>
-      <th>単価(税込)</th>
-    	<th>個数</th>
-    	<th>小計</th>
-    </tr>
+	    <tr>
+	    	<th>商品</th>
+	      <th>単価(税込)</th>
+	    	<th>個数</th>
+	    	<th>小計</th>
+	    </tr>
   	</thead>
   	<tbody>
   	<% @order_details.each do |order_detail| %>
       <tr>
-      <td><%= order_detail.item.name %></td>
-      <td><%= (order_detail.item.price * 1.08).to_i.to_s(:delimited) %>円</td>
-      <td><%= order_detail.count %></td>
-      <td><%= order_detail.price.to_i.to_s(:delimited) %>円</td>
+		    <td><%= order_detail.item.name %></td>
+		    <td><%= (order_detail.item.price * 1.08).to_i.to_s(:delimited) %>円</td>
+		    <td><%= order_detail.count %></td>
+		    <td><%= order_detail.price.to_i.to_s(:delimited) %>円</td>
       </tr>
     <% end %>
     </tbody>

--- a/app/views/public/orders/show.html.erb
+++ b/app/views/public/orders/show.html.erb
@@ -54,7 +54,7 @@
   	<% @order_details.each do |order_detail| %>
       <tr>
 		    <td><%= order_detail.item.name %></td>
-		    <td><%= (order_detail.item.price * 1.08).to_i.to_s(:delimited) %>円</td>
+		    <td><%= (order_detail.item.price * 1.1).to_i.to_s(:delimited) %>円</td>
 		    <td><%= order_detail.count %></td>
 		    <td><%= order_detail.price.to_i.to_s(:delimited) %>円</td>
       </tr>

--- a/app/views/public/orders/show.html.erb
+++ b/app/views/public/orders/show.html.erb
@@ -54,9 +54,9 @@
   	<% @order_details.each do |order_detail| %>
       <tr>
 		    <td><%= order_detail.item.name %></td>
-		    <td><%= (order_detail.item.price * 1.1).to_i.to_s(:delimited) %>円</td>
+		    <td><%= order_detail.item.tax_in_price.to_s(:delimited) %>円</td>
 		    <td><%= order_detail.count %></td>
-		    <td><%= order_detail.price.to_i.to_s(:delimited) %>円</td>
+		    <td><%= order_detail.tax_in_price.to_s(:delimited) %>円</td>
       </tr>
     <% end %>
     </tbody>


### PR DESCRIPTION
order_detailsのpriceが単体価格になっていたので合計値に変更。
税率が1.08になっているミスがあったので1.1に変更。 
税込計算が各所で三者三様の書き方になっていたのを1箇所に統一。
インデントの修正と無駄な空白の削除。